### PR TITLE
Tabs文案语言类型展示错乱

### DIFF
--- a/src/layouts/components/Tabs.tsx
+++ b/src/layouts/components/Tabs.tsx
@@ -63,6 +63,8 @@ function LayoutTabs() {
         setActiveKey(newItems.key);
         setNav(newItems.nav);
         addTabs(newItems);
+        // 初始化Tabs时，更新文案语言类型
+        switchTabsLang(currentLanguage);
       } else {
         setActiveKey(path);
       }
@@ -77,7 +79,7 @@ function LayoutTabs() {
   useEffect(() => {
     switchTabsLang(currentLanguage);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentLanguage, tabs]);
+  }, [currentLanguage]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
复现步骤：语言类型选为English后，刷新页面Tabs文案展示错乱。
![image](https://github.com/user-attachments/assets/24c75356-94b8-462c-b089-19d68dc8cb39)
